### PR TITLE
add scripts to setup db on docker and run website

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM php:7.2-apache
+RUN docker-php-ext-install mysqli && docker-php-ext-enable mysqli

--- a/includes/php/mysqli.php
+++ b/includes/php/mysqli.php
@@ -1,7 +1,7 @@
 <?php
 $dbhandle = new mysqli($hostdb, $userdb, $passdb, $namedb);
-if ($dbhandle->connect_error) {
-    exit("There was an error with your connection: ".$dbhandle->connect_error);
+if (!$dbhandle) {
+    exit("There was an error with your connection: ".mysqli_connect_errno());
 }
 $dbhandle->set_charset('utf8mb4');
 ?>

--- a/includes/php/settings.php
+++ b/includes/php/settings.php
@@ -1,0 +1,25 @@
+<?php
+
+$baseurl = "http://localhost/"; // change this to match the rul you will be accessing the app from
+
+// controller info
+
+$controlleruser     = ''; // the user name for access to the UniFi Controller
+$controllerpassword = ''; // the password for access to the UniFi Controller
+$controllerurl      = ''; // full url to the UniFi Controller, eg. 'https://22.22.11.11:8443'
+$controllerversion  = '5.12.35'; // the version of the Controller software, eg. '4.6.6' (must be at least 4.0.0)
+
+// db settings
+
+$hostdb = "db"; // MySQl server
+$userdb = "unifi"; // MySQL user
+$passdb = "password"; // MySQL password
+$namedb = "unifi"; // MySQL database name
+
+// other setings, should not need to be changed
+
+$singlesite = false;
+$site_id = '';
+$debug = false;
+
+?>

--- a/run-web.sh
+++ b/run-web.sh
@@ -1,0 +1,3 @@
+
+docker run --rm -p 80:80 -v $(pwd):/var/www/html/ --link mariadbtest:db -it unifi-json
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,2 @@
+docker run --name mariadbtest -e MYSQL_ROOT_PASSWORD=mypass -e MYSQL_USER=unifi -e MYSQL_PASSWORD=password -e MYSQL_DATABASE=unifi  -d mariadb/server:10.1
+docker exec -i some-mariadb sh -c 'exec mysql -uroot -p"password"' < db.sql


### PR DESCRIPTION
Hello,

Added scripts for using docker to start the db and webserver for your repo.
This just requires running three steps to get it working after a checkout.

update includes/php/settings.php
setup.sh
run-web.sh